### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/cl-cache-tables.asd
+++ b/cl-cache-tables.asd
@@ -7,12 +7,15 @@
            :license "MIT"
            :serial t
            :components ((:file "package")
-                        (:file "cl-cache-tables")))
+                        (:file "cl-cache-tables"))
+           :in-order-to ((test-op (test-op #:cl-cache-tables/tests))))
 
-(defsystem #:cl-cache-tables-tests
+(defsystem #:cl-cache-tables/tests
            :name "cl-cache-tables-tests"
            :version "0.0.1"
            :description "The tests for the cl-cache-tables system"
            :author "Diogo Franco"
+           :defsystem-depends-on (#:prove-asdf)
            :depends-on (#:cl-cache-tables #:prove)
-           :components ((:file "tests")))
+           :components ((:test-file "tests"))
+           :perform (test-op (o c) (symbol-call :prove :run c)))


### PR DESCRIPTION
ASDF3 recommends declaring a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)
